### PR TITLE
Fix minor plaintext typos and punctuations

### DIFF
--- a/02_estimation.qmd
+++ b/02_estimation.qmd
@@ -238,7 +238,7 @@ Suppose $X_i$ is the answer to a question, "How much do you agree with the follo
 
 The population distribution describes the probability of randomly selecting a person with each one of these values, $\P(X_i = x)$. The empirical distribution would be the fraction of our data taking each value. And the sampling distribution of the sample mean, $\Xbar_n$, would be the distribution of the sample mean across repeated samples from the population. 
 
-Suppose the population distribution was binomial with four trials and probability of success $p = 0.4$. We could generate one sample with $n = 10$ and thus one empirical distribution using `rbinom`:
+Suppose the population distribution was binomial with four trials and probability of success $p = 0.4$. We could generate one sample with $n = 10$ and thus one empirical distribution using `rbinom()`:
 
 ```{r}
 #| echo: false

--- a/03_asymptotics.qmd
+++ b/03_asymptotics.qmd
@@ -81,7 +81,7 @@ $$
 
 ::: {.proof}
 
-Notice that we can let $Y = |X|/\delta$ and rewrite the statement as $\P(Y \geq 1) \leq \E[Y]$ (since $E[|X|]/\delta = \E[|X|/\delta]$ by the properties of expectation), which is what we will show. But notice that
+Notice that we can let $Y = |X|/\delta$ and rewrite the statement as $\P(Y \geq 1) \leq \E[Y]$ (since $\E[|X|]/\delta = \E[|X|/\delta]$ by the properties of expectation), which is what we will show. But notice that
 $$
 \mathbb{1}(Y \geq 1) \leq Y.
 $$
@@ -156,7 +156,7 @@ It can be helpful to see how the distribution of the sample mean changes as a fu
 #| label: "fig-lln-sim"
 #| echo: false
 #| fig-cap: "Sampling distribution of the sample mean as a function of
-#| sample size"
+#| sample size."
 nsims <- 10000
 holder <- matrix(NA, nrow = nsims, ncol = 6)
 for (i in 1:nsims) {
@@ -666,7 +666,7 @@ by the properties of variances.
 ```{r}
 #| label: "fig-delta"
 #| echo: false
-#| fig-cap: "Linear approximation to nonlinear functions"
+#| fig-cap: "Linear approximation to nonlinear functions."
 
 curve(x ^ 2, from = -3, to = 3, lwd = 2, bty = "l", ylim = c(0, 10),
       xaxt = "n", yaxt = "n", xlab = expression(theta), ylab = expression(h(theta)))

--- a/04_hypothesis_tests.qmd
+++ b/04_hypothesis_tests.qmd
@@ -124,7 +124,7 @@ $$
 
 You can think of the size of a test as the rate of false positives (or false discoveries) produced by the test. @fig-size-power shows an example of rejection regions, size, and power for a one-sided test. In the left panel, we have the distribution of the test statistic under the null, with $H_0: \theta = \theta_0$, and the rejection region is defined by values $T > c$. The shaded grey region is the probability of rejection under this null hypothesis or the size of the test. Sometimes, we will get extreme samples by random chance, even under the null, leading to false discoveries.[^3]
 
-[^3]: Eagle-eyed readers will notice that the null tested here is a point, while we previously defined the null in a one-sided test as a region $H_0: \theta \leq \theta_0$. Technically, the size of the test will vary based on which of these nulls we pick. In this example, notice that any null to the left of $\theta_0$ will result in a lower size. And so, the null at the boundary, $\theta_0$, will maximize the size of the test, making it the most "conservative" null to investigate. Technically, we should define the size of a test as $\alpha = \sup_{\theta \in \Theta_0} \pi(\theta)$, 
+[^3]: Eagle-eyed readers will notice that the null tested here is a point, while we previously defined the null in a one-sided test as a region $H_0: \theta \leq \theta_0$. Technically, the size of the test will vary based on which of these nulls we pick. In this example, notice that any null to the left of $\theta_0$ will result in a lower size. And so, the null at the boundary, $\theta_0$, will maximize the size of the test, making it the most "conservative" null to investigate. Technically, we should define the size of a test as $\alpha = \sup_{\theta \in \Theta_0} \pi(\theta)$. 
 
 In the right panel, we overlay the distribution of the test statistic under one particular alternative, $\theta = \theta_1 > \theta_0$. The red-shaded region is the probability of rejecting the null when this alternative is true or the power---it's the probability of correctly rejecting the null when it is false. Intuitively, we can see that alternatives that produce test statistics closer to the rejection region will have higher power. This makes sense: detecting big deviations from the null should be easier than detecting minor ones. 
 
@@ -133,7 +133,7 @@ In the right panel, we overlay the distribution of the test statistic under one 
 ```{r}
 #| label: fig-size-power
 #| echo: false
-#| fig-cap: "Size of a test and power against an alternative"
+#| fig-cap: "Size of a test and power against an alternative."
 par(mfrow = c(1,2), mar = c(5.1, 0, 4.1, 3.1))
 curve(dnorm(x), from = -4, to = 4, ylim = c(0, 0.6), bty = "n", las = 1, xlab = "T under the null hypothesis", ylab = "", xaxt = "n", yaxt = "n", col = "black", lwd = 2, main = "Size")
 axis(side = 1, at = c(-10, 0, 2.32, 10), labels = c("b", expression(theta[0]), expression(c), "d"),
@@ -384,14 +384,14 @@ The Wald test above relies on large sample approximations. In finite samples, th
 $$ 
 T_n = \frac{\Xbar_n - \mu_0}{s_n/\sqrt{n}} \sim t_{n-1},
 $$
-where $t_{n-1} is the $**Student's t-distribution** with $n-1$ degrees of freedom. This result implies the null distribution is $t$, so we use quantiles of $t$ for critical values. For one-sided test $c = G^{-1}_0(1 - \alpha)$ but now $G_0$ is $t$ with $n-1$ df and so we use  `qt()` instead of `qnorm()` to calculate these critical values. 
+where $t_{n-1}$ is the **Student's t-distribution** with $n-1$ degrees of freedom. This result implies the null distribution is $t$, so we use quantiles of $t$ for critical values. For one-sided test $c = G^{-1}_0(1 - \alpha)$ but now $G_0$ is $t$ with $n-1$ df and so we use  `qt()` instead of `qnorm()` to calculate these critical values. 
 
 The critical values for the $t$ distribution are always larger than the normal because the t has fatter tails, as shown in @fig-shape-of-t. As $n\to\infty$, however, the $t$ converges to the standard normal, and so it is asymptotically equivalent to the Wald test but slightly more conservative in finite samples. Oddly, most software packages calculate p-values and rejection regions based on the $t$ to exploit this conservativeness. 
 
 ```{r}
 #| label: fig-shape-of-t
 #| echo: false
-#| fig-cap: "Normal versus t distribution"
+#| fig-cap: "Normal versus t distribution."
 curve(dnorm(x), from = -5, to = 5, lwd = 2, bty = "n", ylab = "f(x)", las = 1)
 curve(dt(x, df = 5), from = -5, to = 5, add = TRUE, lwd = 2, col = "dodgerblue")
 legend(x = -4, y = 0.3, legend = c("Normal", "t (df = 5)"), lwd = 2, col = c("black", "dodgerblue"), bty = "n")

--- a/06_linear_model.qmd
+++ b/06_linear_model.qmd
@@ -499,7 +499,7 @@ The best linear predictor is, of course, a *linear* approximation to the CEF, an
 ```{r}
 #| label: fig-blp-limits
 #| echo: false
-#| fig.cap: "Linear projections for when truncating income distribution below $50k and above $100k"
+#| fig.cap: "Linear projections for when truncating income distribution below $50k and above $100k."
 contour(z, levels = seq(0.0005, 0.008, length.out = 10), col = adjustcolor(my.cols, alpha = 0), drawlabels = FALSE, xlab = "Income", ylab = "Wait Times", las = 1, bty = "n", xaxt = "n")
 axis(side = 1, at = c(2.5, 5, 10, 15, 20), labels = c("$25k", "$50k", "100k", "150k", "200k"))
 curve(exp(4 - x * 0.15), from = -4, to = 22, add = TRUE, col = "indianred", lwd = 3)

--- a/07_least_squares.qmd
+++ b/07_least_squares.qmd
@@ -8,7 +8,7 @@ In this chapter, we focus on motivating the estimator and the mechanical or alge
 ```{r}
 #| label: fig-ajr-scatter
 #| echo: false
-#| fig.cap: Relationship between political institutions and economic development from Acemoglu, Johnson, and Robinson (2001)
+#| fig.cap: Relationship between political institutions and economic development from Acemoglu, Johnson, and Robinson (2001).
 ajr <- foreign::read.dta("assets/data/ajr.dta") 
 
 mod <- lm(logpgp95 ~ avexpr, data = ajr)
@@ -337,7 +337,7 @@ Let $\mathcal{C}(\Xmat) = \{\Xmat\mb{b} : \mb{b} \in \mathbb{R}^2\}$ be the **co
 
 Another interpretation of the OLS estimator is that it finds the linear predictor as the closest point in the column space of $\Xmat$ to the outcome vector $\mb{Y}$. This is called the **projection** of $\mb{Y}$ onto $\mathcal{C}(\Xmat)$. @fig-projection shows this projection for a case with $n=3$ and 2 columns in $\Xmat$. The shaded blue region represents the plane of the column space of $\Xmat$, and we can see that $\Xmat\bhat$ is the closest point to $\mb{Y}$ in that space. That's the whole idea of the OLS estimator: find the linear combination of the columns of $\Xmat$ (a point in the column space) that minimizes the Euclidean distance between that point and the outcome vector (the sum of squared residuals).
 
-![Projection of Y on the column space of the covariates](assets/img/projection-drawing.png){#fig-projection}
+![Projection of Y on the column space of the covariates.](assets/img/projection-drawing.png){#fig-projection}
 
 This figure shows that the residual vector, which is the difference between the $\mb{Y}$ vector and the projection $\Xmat\bhat$ is perpendicular or orthogonal to the column space of $\Xmat$. This orthogonality is a consequence of the residuals being orthogonal to all the columns of $\Xmat$,
 $$ 
@@ -489,7 +489,7 @@ In the context of OLS, an **outlier** is an observation with a large prediction 
 ```{r}
 #| label: fig-outlier
 #| echo: false
-#| fig.cap: An example of an outlier
+#| fig.cap: An example of an outlier.
 
 set.seed(02138)
 x <- rnorm(100, 0, 1)


### PR DESCRIPTION
- It fixes a misplaced `$` in **04_hypothesis_tests.qmd**.
- It replaces an expectation operator `E` with `\E` in **03_asymptotics.qmd**.
- The rest fixes punctuations in the figure captions and footnotes.

Thank you for the great resource!